### PR TITLE
[DO NOT MERGE] Remove hash check from updateCheck

### DIFF
--- a/core/services/client-manager.js
+++ b/core/services/client-manager.js
@@ -175,8 +175,7 @@ proto.updateCheck = function(deploymentKey, appVersion, label, packageHash, clie
     return models.Packages.findById(packageId)
     .then((packages) => {
       if (packages
-        && _.eq(packages.deployment_id, deploymentsVersions.deployment_id)
-        && !_.eq(packages.package_hash, packageHash)) {
+        && _.eq(packages.deployment_id, deploymentsVersions.deployment_id)) {
         rs.packageId = packageId;
         rs.downloadUrl = rs.downloadURL = common.getBlobDownloadUrl(_.get(packages, 'blob_url'));
         rs.description = _.get(packages, 'description', '');


### PR DESCRIPTION
The updateCheck method doesn't populate the package object if current hash equals the package hash. It's better to return the full package info object anyway and decide in the client whether to download it.
Should be released together the corresponding changes in the appsync-sdk.